### PR TITLE
Fix for flat dependencies tree css resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var insertCSS = require('insert-css')
 module.exports = function(opts) {
   if (!opts) opts = {}
   
-  var cmStyle = fs.readFileSync(__dirname + '/node_modules/codemirror/lib/codemirror.css')
+  var cmStyle = fs.readFileSync(require.resolve('codemirror/lib/codemirror.css'))
   insertCSS(cmStyle)
     
   var defaults = {


### PR DESCRIPTION
Since npm 3 has total dependency awareness and is flattened immediately, `edit` struggles to resolve the codemirror css in most cases now.

Using `require.resolve` to leverage the existing dep resolution instead.

**edit**: to clarify, not saying it's an npm 3 only thing, just a `dedupe` thing. :grinning: 
